### PR TITLE
상품 등록 로직 개선 및 서비스 테스트 코드 추가

### DIFF
--- a/src/main/java/com/sellect/server/product/application/ProductService.java
+++ b/src/main/java/com/sellect/server/product/application/ProductService.java
@@ -1,4 +1,4 @@
-package com.sellect.server.product.controller.application;
+package com.sellect.server.product.application;
 
 import com.sellect.server.category.repository.CategoryRepository;
 import com.sellect.server.product.controller.request.ProductRegisterRequest;

--- a/src/main/java/com/sellect/server/product/application/ProductService.java
+++ b/src/main/java/com/sellect/server/product/application/ProductService.java
@@ -23,7 +23,8 @@ public class ProductService {
 
     // todo : 이미지 고려 안 함 아직 S3 없음
     @Transactional
-    public ProductRegisterResponse registerMultiple(Long sellerId, List<ProductRegisterRequest> requests) {
+    public ProductRegisterResponse registerMultiple(Long sellerId,
+        List<ProductRegisterRequest> requests) {
         List<Product> successProducts = new ArrayList<>();
         List<ProductRegisterFailureResponse> failedProducts = new ArrayList<>();
 
@@ -31,52 +32,45 @@ public class ProductService {
         Set<String> requestProductNames = new HashSet<>();
 
         for (ProductRegisterRequest request : requests) {
-            try {
-                // 요청 내 상품 기준 중복 검사
-                if (!requestProductNames.add(request.name())) {
-                    failedProducts.add(
-                        ProductRegisterFailureResponse.from(request.name(), "요청 내 중복된 상품명")
-                    );
-                    continue;
-                }
-
-                // 존재하지 않는 카테고리 체크
-                if (!categoryRepository.isExistCategory(request.categoryId(), null)) {
-                    System.out.println(
-                        categoryRepository.isExistCategory(request.categoryId(), null));
-                    failedProducts.add(
-                        ProductRegisterFailureResponse.from(request.name(), "존재하지 않는 카테고리"));
-                    continue;
-                }
-
-                // 등록된 상품 기준 중복 검사 (sellerId, productName 기준)
-                if (productRepository.isDuplicateProduct(sellerId, request.name(), null)) {
-                    failedProducts.add(
-                        ProductRegisterFailureResponse.from(request.name(), "중복 상품"));
-                    continue;
-                }
-
-                // todo : 상품당 이미지는 필수
-
-
-                successProducts.add(Product.register(
-                    sellerId,
-                    request.categoryId(),
-                    request.brandId(),
-                    request.getPriceAsBigDecimal(), // String -> BigDecimal 변환
-                    request.name(),
-                    request.stock()
-                ));
-
-            } catch (Exception e) {
-                // 알 수 없는 예외 발생 시 실패 처리
+            // 요청 내 상품 기준 중복 검사
+            if (!requestProductNames.add(request.name())) {
                 failedProducts.add(
-                    ProductRegisterFailureResponse.from(request.name(), "알 수 없는 오류 발생"));
+                    ProductRegisterFailureResponse.from(request.name(), "요청 내 중복된 상품명")
+                );
+                continue;
             }
+
+            // 존재하지 않는 카테고리 체크
+            if (!categoryRepository.isExistCategory(request.categoryId(), null)) {
+                System.out.println(
+                    categoryRepository.isExistCategory(request.categoryId(), null));
+                failedProducts.add(
+                    ProductRegisterFailureResponse.from(request.name(), "존재하지 않는 카테고리"));
+                continue;
+            }
+
+            // 등록된 상품 기준 중복 검사 (sellerId, productName 기준)
+            if (productRepository.isDuplicateProduct(sellerId, request.name(), null)) {
+                failedProducts.add(
+                    ProductRegisterFailureResponse.from(request.name(), "중복 상품"));
+                continue;
+            }
+
+            // todo : 상품당 이미지는 필수
+
+            successProducts.add(Product.register(
+                sellerId,
+                request.categoryId(),
+                request.brandId(),
+                request.getPriceAsBigDecimal(), // String -> BigDecimal 변환
+                request.name(),
+                request.stock()
+            ));
+
         }
 
         // 기획 : 실패한 게 하나도 없을 때에만 등록이 가능
-        if (!failedProducts.isEmpty()) {
+        if (failedProducts.isEmpty()) {
             productRepository.saveAll(successProducts);
         }
 

--- a/src/main/java/com/sellect/server/product/controller/ProductController.java
+++ b/src/main/java/com/sellect/server/product/controller/ProductController.java
@@ -1,7 +1,7 @@
 package com.sellect.server.product.controller;
 
 import com.sellect.server.common.response.ApiResponse;
-import com.sellect.server.product.controller.application.ProductService;
+import com.sellect.server.product.application.ProductService;
 import com.sellect.server.product.controller.request.ProductRegisterRequest;
 import com.sellect.server.product.controller.response.ProductRegisterResponse;
 import java.util.List;

--- a/src/main/java/com/sellect/server/product/controller/ProductController.java
+++ b/src/main/java/com/sellect/server/product/controller/ProductController.java
@@ -4,6 +4,7 @@ import com.sellect.server.common.response.ApiResponse;
 import com.sellect.server.product.application.ProductService;
 import com.sellect.server.product.controller.request.ProductRegisterRequest;
 import com.sellect.server.product.controller.response.ProductRegisterResponse;
+import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -25,7 +26,7 @@ public class ProductController {
     // todo : sellerId token 에서 가져오도록 변경할 것!!
     // todo : 상품 이미지 관련 로직 추가할 것!!
     public ApiResponse<ProductRegisterResponse> registerMultiple(Long sellerId,
-        @RequestBody List<ProductRegisterRequest> requests) {
+        @Valid @RequestBody List<ProductRegisterRequest> requests) {
 
         ProductRegisterResponse result = productService.registerMultiple(sellerId,
             requests);

--- a/src/main/java/com/sellect/server/product/controller/response/ProductRegisterResponse.java
+++ b/src/main/java/com/sellect/server/product/controller/response/ProductRegisterResponse.java
@@ -4,8 +4,8 @@ import com.sellect.server.product.domain.Product;
 import java.util.List;
 
 public record ProductRegisterResponse(
-    List<ProductRegisterSuccessResponse> success,
-    List<ProductRegisterFailureResponse> failed
+    List<ProductRegisterSuccessResponse> successProducts,
+    List<ProductRegisterFailureResponse> failedProducts
 ) {
 
     public static ProductRegisterResponse from(

--- a/src/test/java/com/sellect/server/category/repository/FakeCategoryRepository.java
+++ b/src/test/java/com/sellect/server/category/repository/FakeCategoryRepository.java
@@ -1,0 +1,30 @@
+package com.sellect.server.category.repository;
+
+import com.sellect.server.category.domain.Category;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+public class FakeCategoryRepository implements CategoryRepository {
+
+    private final List<Category> data = new ArrayList<>();
+
+    @Override
+    public boolean isExistCategory(Long categoryId, LocalDateTime deleteAt) {
+        return data.stream()
+            .anyMatch(category -> category.getId().equals(categoryId) &&
+                (deleteAt == null || category.getDeleteAt() == null));
+    }
+
+    public void save(Category category) {
+        data.add(category);
+    }
+
+    public List<Category> findAll() {
+        return new ArrayList<>(data);
+    }
+
+    public void clear() {
+        data.clear();
+    }
+}

--- a/src/test/java/com/sellect/server/product/application/ProductServiceTest.java
+++ b/src/test/java/com/sellect/server/product/application/ProductServiceTest.java
@@ -1,0 +1,132 @@
+package com.sellect.server.product.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.sellect.server.category.domain.Category;
+import com.sellect.server.category.repository.FakeCategoryRepository;
+import com.sellect.server.product.controller.request.ProductRegisterRequest;
+import com.sellect.server.product.controller.response.ProductRegisterResponse;
+import com.sellect.server.product.domain.Product;
+import com.sellect.server.product.repository.FakeProductRepository;
+import java.math.BigDecimal;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class ProductServiceTest {
+
+    private final FakeProductRepository productRepository = new FakeProductRepository();
+    private final FakeCategoryRepository categoryRepository = new FakeCategoryRepository();
+    private final ProductService productService = new ProductService(productRepository,
+        categoryRepository);
+
+    @BeforeEach
+    void setUp() {
+        productRepository.clear();
+        categoryRepository.clear();
+    }
+
+    @Nested
+    @DisplayName("상품 등록 테스트")
+    class RegisterMultiple {
+
+        @Test
+        @DisplayName("상품 등록 성공")
+        void test1000() {
+            // Given
+            Long sellerId = 1L;
+            categoryRepository.save(Category.builder()
+                .id(10L)
+                .build());
+
+            List<ProductRegisterRequest> requests = List.of(
+                new ProductRegisterRequest(10L, 1L, "10000", "상품A", 10),
+                new ProductRegisterRequest(10L, 2L, "20000", "상품B", 20)
+            );
+
+            // When
+            ProductRegisterResponse response = productService.registerMultiple(sellerId, requests);
+
+            // Then
+            assertThat(response.successProducts()).hasSize(2);
+            assertThat(response.failedProducts()).isEmpty();
+        }
+
+        @Test
+        @DisplayName("요청 내 중복된 상품명이 존재하면 실패한다.")
+        void test1() {
+            // Given
+            Long sellerId = 1L;
+            categoryRepository.save(Category.builder()
+                .id(10L)
+                .build());
+
+            List<ProductRegisterRequest> requests = List.of(
+                new ProductRegisterRequest(10L, 1L, "10000", "상품A", 10),
+                new ProductRegisterRequest(10L, 2L, "20000", "상품A", 20) // 중복된 상품명
+            );
+
+            // When
+            ProductRegisterResponse response = productService.registerMultiple(sellerId, requests);
+
+            // Then
+            assertThat(response.successProducts()).hasSize(1);
+            assertThat(response.failedProducts()).hasSize(1);
+            assertThat(response.failedProducts().get(0).reason()).isEqualTo("요청 내 중복된 상품명");
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 카테고리는 등록할 수 없다.")
+        void test2() {
+            // Given
+            Long sellerId = 1L;
+
+            List<ProductRegisterRequest> requests = List.of(
+                new ProductRegisterRequest(999L, 1L, "10000", "상품A", 10) // 존재하지 않는 카테고리
+            );
+
+            // When
+            ProductRegisterResponse response = productService.registerMultiple(sellerId, requests);
+
+            // Then
+            assertThat(response.successProducts()).isEmpty();
+            assertThat(response.failedProducts()).hasSize(1);
+            assertThat(response.failedProducts().get(0).reason()).isEqualTo("존재하지 않는 카테고리");
+        }
+
+        @Test
+        @DisplayName("이미 등록된 상품명이 존재하면 등록할 수 없다.")
+        void test3() {
+            // Given
+            Long sellerId = 1L;
+            categoryRepository.save(Category.builder()
+                .id(10L)
+                .build());
+
+            productRepository.save(
+                Product.builder()
+                    .sellerId(sellerId)
+                    .categoryId(10L)
+                    .brandId(1L)
+                    .price(new BigDecimal("10000"))
+                    .name("상품A")
+                    .stock(10)
+                    .build()
+            );
+
+            List<ProductRegisterRequest> requests = List.of(
+                new ProductRegisterRequest(10L, 1L, "20000", "상품A", 20) // 중복된 상품명
+            );
+
+            // When
+            ProductRegisterResponse response = productService.registerMultiple(sellerId, requests);
+
+            // Then
+            assertThat(response.successProducts()).isEmpty();
+            assertThat(response.failedProducts()).hasSize(1);
+            assertThat(response.failedProducts().get(0).reason()).isEqualTo("중복 상품");
+        }
+    }
+}

--- a/src/test/java/com/sellect/server/product/repository/FakeProductRepository.java
+++ b/src/test/java/com/sellect/server/product/repository/FakeProductRepository.java
@@ -1,0 +1,39 @@
+package com.sellect.server.product.repository;
+
+import com.sellect.server.product.domain.Product;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+public class FakeProductRepository implements ProductRepository {
+
+    private final List<Product> data = new ArrayList<>();
+
+    @Override
+    public List<Product> saveAll(List<Product> products) {
+        data.addAll(products);
+        return new ArrayList<>(data);
+    }
+
+    @Override
+    public boolean isDuplicateProduct(Long sellerId, String name, LocalDateTime deleteAt) {
+        return data.stream()
+            .anyMatch(product -> product.getSellerId().equals(sellerId) &&
+                product.getName().equals(name) &&
+                (deleteAt == null || product.getDeleteAt() == null));
+    }
+
+    public List<Product> save(Product product) {
+        data.add(product);
+        return new ArrayList<>(data);
+    }
+
+    public List<Product> findAll() {
+        return new ArrayList<>(data);
+    }
+
+    public void clear() {
+        data.clear();
+    }
+
+}


### PR DESCRIPTION
## 📣(제목)
### 📅(날짜 -  2025.02.12)

### 🌵Branch
(feature/product-crud)  → (develop)

### 📢 Description
- `ProductService.registerMultiple()`에서 불필요한 `try-catch` 제거 및 로직 개선
- 실패한 상품(`failedProducts`)을 활용하여 예외 없이 처리하도록 리팩토링
- 중복 상품 검증(`requestProductNames` 사용) 및 카테고리 존재 여부 체크 로직 유지
- 실패한 상품이 하나라도 있으면 DB 저장을 진행하지 않도록 기획 반영


### 🛠️Type
- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정 -
- [x] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

### ✔️PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고 (Ctrl + 클릭하세요.)
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

### 🔖Note
#### 🧪 추가된 테스트
- 상품 등록 성공 케이스
- 요청 내 중복된 상품명 존재 시 실패 처리
- 존재하지 않는 카테고리 등록 불가 검증
- 이미 등록된 상품명 존재 시 중복 방지 검증
- `saveAll()` 실행 중 예기치 못한 예외 발생 시 예외 처리 검증

#### 🚀 기타
- `FakeRepository`를 활용하여 `JpaRepository` 의존성을 제거하고 테스트를 수행하였습니다.