### PR TITLE
검색 자동 완성을 위한 검색 로그 데이터 필터링 작업을 하는 배치 구현

### DIFF
--- a/src/main/java/com/sellect/server/search/domain/AutoCompleteKeyword.java
+++ b/src/main/java/com/sellect/server/search/domain/AutoCompleteKeyword.java
@@ -13,8 +13,20 @@ public class AutoCompleteKeyword {
 
     private final Long id;
     private final String keyword;
-    private final Long frequency;
+    private Long frequency;
     private final LocalDateTime createdAt;
     private final LocalDateTime updatedAt;
     private final LocalDateTime deleteAt;
+
+    // frequency 증가 메서드
+    public AutoCompleteKeyword incrementFrequency(long count) {
+        return AutoCompleteKeyword.builder()
+            .id(this.id)
+            .keyword(this.keyword)
+            .frequency(this.frequency += count)
+            .createdAt(this.createdAt)
+            .updatedAt(LocalDateTime.now())
+            .deleteAt(this.deleteAt)
+            .build();
+    }
 }

--- a/src/main/java/com/sellect/server/search/event/SearchLogEventListener.java
+++ b/src/main/java/com/sellect/server/search/event/SearchLogEventListener.java
@@ -2,7 +2,7 @@ package com.sellect.server.search.event;
 
 import com.sellect.server.search.domain.SearchLog;
 import com.sellect.server.search.repository.SearchLogEntity;
-import com.sellect.server.search.repository.SearchLogJpaRepository;
+import com.sellect.server.search.repository.SearchLogRepository;
 import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.event.EventListener;
@@ -12,8 +12,7 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class SearchLogEventListener {
 
-    // todo: JPA 의존성 끊기??! SearchLogRepository 를 통해서 .
-    private final SearchLogJpaRepository searchLogJpaRepository;
+    private final SearchLogRepository searchLogRepository;
 
     @EventListener
     public void handleSearchLogEvent(SearchLogEvent event) {
@@ -30,6 +29,6 @@ public class SearchLogEventListener {
             .build();
 
         // 도메인 객체 → JPA 엔티티 변환 후 저장
-        searchLogJpaRepository.save(SearchLogEntity.from(searchLog));
+        searchLogRepository.save(SearchLogEntity.from(searchLog).toModel());
     }
 }

--- a/src/main/java/com/sellect/server/search/repository/AutoCompleteKeywordRepository.java
+++ b/src/main/java/com/sellect/server/search/repository/AutoCompleteKeywordRepository.java
@@ -2,9 +2,14 @@ package com.sellect.server.search.repository;
 
 import com.sellect.server.search.domain.AutoCompleteKeyword;
 import java.util.List;
+import java.util.Optional;
 
 public interface AutoCompleteKeywordRepository {
 
     List<AutoCompleteKeyword> findTopKeywordsStartingWith(String query);
+
+    Optional<AutoCompleteKeyword> findByKeyword(String keyword);
+
+    AutoCompleteKeyword save(AutoCompleteKeyword autoCompleteKeyword);
 
 }

--- a/src/main/java/com/sellect/server/search/repository/AutoCompleteKeywordRepositoryImpl.java
+++ b/src/main/java/com/sellect/server/search/repository/AutoCompleteKeywordRepositoryImpl.java
@@ -4,7 +4,11 @@ import com.sellect.server.search.domain.AutoCompleteKeyword;
 import com.sellect.server.search.repository.jpa.AutoCompleteKeywordEntity;
 import com.sellect.server.search.repository.jpa.AutoCompleteKeywordJpaRepository;
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort.Direction;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -17,10 +21,24 @@ public class AutoCompleteKeywordRepositoryImpl implements AutoCompleteKeywordRep
 
     @Override
     public List<AutoCompleteKeyword> findTopKeywordsStartingWith(String query) {
+        Pageable pageable = PageRequest.of(0, MAX_LIMIT, Direction.DESC, "frequency");
         List<AutoCompleteKeywordEntity> findKeywords = autoCompleteKeywordJpaRepository
-            .findTopByKeywordStartingWith(query, MAX_LIMIT);
+            .findTopByKeywordStartingWith(query, pageable);
         return findKeywords.stream()
             .map(AutoCompleteKeywordEntity::toModel)
             .toList();
+    }
+
+    // todo: 기존 데이터 조회 + 업데이트 (JPA 사용) -> AutoCompleteKeyword Entity 조회 영속성 컨텍스트를 거친다.
+    @Override
+    public Optional<AutoCompleteKeyword> findByKeyword(String keyword) {
+        return autoCompleteKeywordJpaRepository.findByKeywordAndDeleteAtIsNull(keyword)
+            .map(AutoCompleteKeywordEntity::toModel);
+    }
+
+    @Override
+    public AutoCompleteKeyword save(AutoCompleteKeyword autoCompleteKeyword) {
+        return autoCompleteKeywordJpaRepository.save(
+            AutoCompleteKeywordEntity.from(autoCompleteKeyword)).toModel();
     }
 }

--- a/src/main/java/com/sellect/server/search/repository/SearchLogJpaBatchJob.java
+++ b/src/main/java/com/sellect/server/search/repository/SearchLogJpaBatchJob.java
@@ -1,0 +1,67 @@
+package com.sellect.server.search.repository;
+
+import com.sellect.server.search.domain.AutoCompleteKeyword;
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class SearchLogJpaBatchJob {
+
+    private final SearchLogRepository searchLogRepository;
+    private final AutoCompleteKeywordRepository autoCompleteKeywordRepository;
+
+    @Transactional
+    @Scheduled(cron = "0 0 2 * * ?") // 매일 오전 2시 실행
+    public void updateAutoCompleteKeyword() {
+        LocalDateTime startTime = LocalDateTime.now().minusDays(1);
+        LocalDateTime endTime = LocalDateTime.now();
+
+        // 1. 조회: 24시간 내 검색 로그 가져오기 (JPA 조회, 영속성 컨텍스트 X)
+        List<Object[]> searchLogs = searchLogRepository.findSearchLogsForBatch(startTime, endTime);
+        System.out.println("배치 시작: " + searchLogs.size() + "개의 검색어 처리 중...");
+
+        // 2. 키워드별 중복 유저 제거 후 빈도수 집계
+        Map<String, Set<String>> keywordUserMap = new HashMap<>();
+        for (Object[] log : searchLogs) {
+            String keyword = (String) log[0];
+            String userIdentifier = (String) log[1];
+
+            keywordUserMap.putIfAbsent(keyword, new HashSet<>());
+            keywordUserMap.get(keyword).add(userIdentifier); // 같은 키워드는 유저별로 중복 제거
+        }
+
+        // 3. `auto_complete_keyword` 테이블 업데이트 (JPA 사용, 영속성 컨텍스트 거침)
+        for (Map.Entry<String, Set<String>> entry : keywordUserMap.entrySet()) {
+            String keyword = entry.getKey();
+            int uniqueUserCount = entry.getValue().size(); // 중복 제거된 유저 수
+
+            Optional<AutoCompleteKeyword> existingKeyword = autoCompleteKeywordRepository.findByKeyword(keyword);
+            if (existingKeyword.isPresent()) {
+                AutoCompleteKeyword autoCompleteKeyword = existingKeyword.get();
+                autoCompleteKeyword.incrementFrequency(uniqueUserCount);
+                autoCompleteKeywordRepository.save(autoCompleteKeyword);
+            } else {
+                AutoCompleteKeyword newKeyword = AutoCompleteKeyword.builder()
+                    .keyword(keyword)
+                    .frequency((long) uniqueUserCount)
+                    .createdAt(LocalDateTime.now())
+                    .updatedAt(LocalDateTime.now())
+                    .deleteAt(null)
+                    .build();
+                autoCompleteKeywordRepository.save(newKeyword);
+            }
+        }
+
+        System.out.println("자동완성 배치 완료!");
+    }
+}

--- a/src/main/java/com/sellect/server/search/repository/SearchLogRepository.java
+++ b/src/main/java/com/sellect/server/search/repository/SearchLogRepository.java
@@ -1,0 +1,9 @@
+package com.sellect.server.search.repository;
+
+import com.sellect.server.search.domain.SearchLog;
+
+public interface SearchLogRepository {
+
+    SearchLog save(SearchLog searchLog);
+
+}

--- a/src/main/java/com/sellect/server/search/repository/SearchLogRepository.java
+++ b/src/main/java/com/sellect/server/search/repository/SearchLogRepository.java
@@ -1,9 +1,13 @@
 package com.sellect.server.search.repository;
 
 import com.sellect.server.search.domain.SearchLog;
+import java.time.LocalDateTime;
+import java.util.List;
 
 public interface SearchLogRepository {
 
     SearchLog save(SearchLog searchLog);
+
+    List<Object[]> findSearchLogsForBatch(LocalDateTime startTime, LocalDateTime endTime);
 
 }

--- a/src/main/java/com/sellect/server/search/repository/SearchLogRepositoryImpl.java
+++ b/src/main/java/com/sellect/server/search/repository/SearchLogRepositoryImpl.java
@@ -1,17 +1,35 @@
 package com.sellect.server.search.repository;
 
 import com.sellect.server.search.domain.SearchLog;
+import jakarta.persistence.EntityManager;
+import java.time.LocalDateTime;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
 @Repository
 @RequiredArgsConstructor
-public class SearchLogRepositoryImpl implements SearchLogRepository{
+public class SearchLogRepositoryImpl implements SearchLogRepository {
 
     private final SearchLogJpaRepository searchLogJpaRepository;
+    private final EntityManager entityManager;
+
 
     @Override
     public SearchLog save(SearchLog searchLog) {
         return searchLogJpaRepository.save(SearchLogEntity.from(searchLog)).toModel();
     }
+
+    // todo: check 사실 엔티티 객체를 조회하는 것이 아니기에 영속성 컨텍스트를 사용하지 않음) -> JdbcTemplate 동일한 방식으로 동작
+    @Override
+    public List<Object[]> findSearchLogsForBatch(LocalDateTime startTime, LocalDateTime endTime) {
+        return entityManager.createQuery(
+                "SELECT s.keyword, s.userIdentifier FROM SearchLogEntity s " +
+                    "WHERE s.timestamp BETWEEN :startTime AND :endTime " +
+                    "AND s.filterApplied = false", Object[].class)
+            .setParameter("startTime", startTime)
+            .setParameter("endTime", endTime)
+            .getResultList();
+    }
+
 }

--- a/src/main/java/com/sellect/server/search/repository/SearchLogRepositoryImpl.java
+++ b/src/main/java/com/sellect/server/search/repository/SearchLogRepositoryImpl.java
@@ -1,0 +1,17 @@
+package com.sellect.server.search.repository;
+
+import com.sellect.server.search.domain.SearchLog;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class SearchLogRepositoryImpl implements SearchLogRepository{
+
+    private final SearchLogJpaRepository searchLogJpaRepository;
+
+    @Override
+    public SearchLog save(SearchLog searchLog) {
+        return searchLogJpaRepository.save(SearchLogEntity.from(searchLog)).toModel();
+    }
+}

--- a/src/main/java/com/sellect/server/search/repository/jpa/AutoCompleteKeywordJpaRepository.java
+++ b/src/main/java/com/sellect/server/search/repository/jpa/AutoCompleteKeywordJpaRepository.java
@@ -1,6 +1,8 @@
 package com.sellect.server.search.repository.jpa;
 
 import java.util.List;
+import java.util.Optional;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -8,12 +10,12 @@ import org.springframework.data.repository.query.Param;
 public interface AutoCompleteKeywordJpaRepository extends JpaRepository<AutoCompleteKeywordEntity, Long> {
 
     @Query("SELECT s FROM AutoCompleteKeywordEntity s "
-        + "WHERE s.keyword LIKE :prefix% "
-        + "ORDER BY s.frequency DESC "
-        + "LIMIT :limit")
+        + "WHERE s.keyword LIKE :prefix%")
     List<AutoCompleteKeywordEntity> findTopByKeywordStartingWith(
         @Param("prefix") String prefix,
-        @Param("limit") int limit
+        Pageable pageable
     );
+
+    Optional<AutoCompleteKeywordEntity> findByKeywordAndDeleteAtIsNull(String keyword);
 
 }

--- a/src/test/java/com/sellect/server/search/repository/FakeAutoCompleteKeywordRepository.java
+++ b/src/test/java/com/sellect/server/search/repository/FakeAutoCompleteKeywordRepository.java
@@ -4,6 +4,7 @@ import com.sellect.server.search.domain.AutoCompleteKeyword;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Optional;
 
 public class FakeAutoCompleteKeywordRepository implements AutoCompleteKeywordRepository {
 
@@ -20,9 +21,18 @@ public class FakeAutoCompleteKeywordRepository implements AutoCompleteKeywordRep
             .toList();
     }
 
-    public void save(AutoCompleteKeyword autoCompleteKeyword) {
-        data.add(autoCompleteKeyword);
+    // todo: 테스트 코드 작성 시 구현
+    @Override
+    public Optional<AutoCompleteKeyword> findByKeyword(String keyword) {
+        return Optional.empty();
     }
+
+    // todo: 테스트 코드 작성 시 구현
+    @Override
+    public AutoCompleteKeyword save(AutoCompleteKeyword autoCompleteKeyword) {
+        return null;
+    }
+
 
     public void saveAll(List<AutoCompleteKeyword> autoCompleteKeywords) {
         data.addAll(autoCompleteKeywords);


### PR DESCRIPTION
## 📣(제목) 검색 자동 완성을 위한 검색 로그 데이터 필터링 작업을 하는 배치 구현
### 📅(날짜 -  2025.02.19)

### 🌵Branch
(feature/search-log-batch)  → (develop)

### 📢 Description
- 배치 작업은 오전 2:00시에 진행
- AutoCompleteJpaRepository에서 LIMIT 관련 에러 해결
- JPQL에서는 LIMIT 사용 안되기에 Pageable()로 해결


### 🛠️Type
- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정 -
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

### ✔️PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고 (Ctrl + 클릭하세요.)
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

### 🔖Note
(참고사항을 적어주세요)