### PR TITLE
PaymentService에 대한 로직 변경 및 이벤트리스너에서 preparePayment의 경우에는 동기로 (톰캣 스레드가 처리하도록 변경) - 불필요한 스레드 2개를 사용하는 걸 방지(톰캣, 스프링 스레드)

### DIFF
--- a/src/main/java/com/sellect/server/config/AsyncConfig.java
+++ b/src/main/java/com/sellect/server/config/AsyncConfig.java
@@ -19,16 +19,16 @@ public class AsyncConfig {
         return executor;
     }
 
-    @Bean(name = "preparePaymentExecutor")
-    public ThreadPoolTaskExecutor preparePaymentExecutor() {
-        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
-        executor.setCorePoolSize(5);
-        executor.setMaxPoolSize(10);
-        executor.setQueueCapacity(50);
-        executor.setThreadNamePrefix("preparePaymentExecutor AsyncThread - ");
-        executor.initialize();
-        return executor;
-    }
+//    @Bean(name = "preparePaymentExecutor")
+//    public ThreadPoolTaskExecutor preparePaymentExecutor() {
+//        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+//        executor.setCorePoolSize(5);
+//        executor.setMaxPoolSize(10);
+//        executor.setQueueCapacity(50);
+//        executor.setThreadNamePrefix("preparePaymentExecutor AsyncThread - ");
+//        executor.initialize();
+//        return executor;
+//    }
 
     @Bean(name = "approvePaymentExecutor")
     public ThreadPoolTaskExecutor approvePaymentExecutor() {

--- a/src/main/java/com/sellect/server/order/application/v0/OrderServiceV0After.java
+++ b/src/main/java/com/sellect/server/order/application/v0/OrderServiceV0After.java
@@ -12,7 +12,7 @@ import com.sellect.server.order.domain.Orders;
 import com.sellect.server.order.repository.OrderItemRepository;
 import com.sellect.server.order.repository.OrdersRepository;
 import com.sellect.server.order.domain.OrderStatus;
-import com.sellect.server.payment.application.PaymentServiceV0;
+import com.sellect.server.payment.application.v0.PaymentServiceV0;
 import com.sellect.server.payment.domain.Payment;
 import com.sellect.server.product.domain.Inventory;
 import com.sellect.server.product.repository.InventoryRepository;

--- a/src/main/java/com/sellect/server/order/application/v0/OrderServiceV0Before.java
+++ b/src/main/java/com/sellect/server/order/application/v0/OrderServiceV0Before.java
@@ -12,7 +12,7 @@ import com.sellect.server.order.domain.Orders;
 import com.sellect.server.order.repository.OrderItemRepository;
 import com.sellect.server.order.repository.OrdersRepository;
 import com.sellect.server.order.domain.OrderStatus;
-import com.sellect.server.payment.application.PaymentServiceV0;
+import com.sellect.server.payment.application.v0.PaymentServiceV0;
 import com.sellect.server.payment.domain.Payment;
 import com.sellect.server.product.domain.Inventory;
 import com.sellect.server.product.repository.InventoryRepository;

--- a/src/main/java/com/sellect/server/order/application/v1/OrderServiceV1After.java
+++ b/src/main/java/com/sellect/server/order/application/v1/OrderServiceV1After.java
@@ -150,6 +150,7 @@ public class OrderServiceV1After {
 
             inventoryRepository.saveAll(deductedInventories);
             ordersRepository.save(order.completeOrder());
+            payment = paymentRepository.save(payment.approve());
 
             // 트랜잭션 커밋
             transactionManager.commit(status);

--- a/src/main/java/com/sellect/server/order/application/v1/OrderServiceV1After.java
+++ b/src/main/java/com/sellect/server/order/application/v1/OrderServiceV1After.java
@@ -1,33 +1,29 @@
 package com.sellect.server.order.application.v1;
 
 import com.sellect.server.auth.domain.User;
-import com.sellect.server.auth.repository.user.UserRepository;
 import com.sellect.server.common.exception.CommonException;
 import com.sellect.server.common.exception.enums.BError;
 import com.sellect.server.coupon.domain.Coupon;
 import com.sellect.server.coupon.domain.UserReceivedCoupon;
 import com.sellect.server.order.Infrastructure.response.KakaoPayReadyResponse;
+import com.sellect.server.order.application.v1.approvepayment.ApprovePaymentStrategy;
 import com.sellect.server.order.controller.request.OrderAddRequest;
 import com.sellect.server.order.controller.response.OrderDetailGetResponse;
 import com.sellect.server.order.controller.response.OrderGetResponse;
 import com.sellect.server.order.controller.response.OrderItemGetResponse;
 import com.sellect.server.order.controller.response.PendingOrderRegisterResponse;
 import com.sellect.server.order.domain.OrderItem;
+import com.sellect.server.order.domain.OrderStatus;
 import com.sellect.server.order.domain.Orders;
 import com.sellect.server.order.repository.OrderItemRepository;
 import com.sellect.server.order.repository.OrdersRepository;
-import com.sellect.server.order.domain.OrderStatus;
-import com.sellect.server.payment.domain.Payment;
-import com.sellect.server.payment.event.KakaoPayApproveEvent;
 import com.sellect.server.payment.event.KakaoPayReadyEvent;
-import com.sellect.server.payment.repository.PaymentRepository;
 import com.sellect.server.product.domain.Inventory;
 import com.sellect.server.product.domain.Product;
 import com.sellect.server.product.repository.InventoryRepository;
 import com.sellect.server.product.repository.ProductImageRepository;
 import com.sellect.server.product.repository.ProductRepository;
 import java.math.BigDecimal;
-import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
@@ -51,17 +47,16 @@ import org.springframework.transaction.support.DefaultTransactionDefinition;
 @Slf4j
 public class OrderServiceV1After {
 
+    private final ApprovePaymentStrategy approvePaymentStrategy;
     private final OrdersRepository ordersRepository;
     private final OrderItemRepository orderItemRepository;
     private final ProductRepository productRepository;
     private final InventoryRepository inventoryRepository;
     private final ProductImageRepository productImageRepository;
-    private final UserRepository userRepository;
-    private final PaymentRepository paymentRepository;
     private final ApplicationEventPublisher eventPublisher;
     private final PlatformTransactionManager transactionManager;
 
-    // 주문 결제
+
     public KakaoPayReadyResponse preparePayment(User user, Long orderId) {
 
         // 트랜잭션 정의 및 시작
@@ -105,70 +100,10 @@ public class OrderServiceV1After {
         }
     }
 
+
     public void approvePayment(final Long pid, final String token) {
-
-        // 트랜잭션 정의 및 시작
-        TransactionDefinition definition = new DefaultTransactionDefinition();
-        TransactionStatus status = transactionManager.getTransaction(definition);
-
-        Payment payment;
-        Orders order;
-
-        try {
-            payment = paymentRepository.findByPid(pid)
-                .orElseThrow(() -> new CommonException(
-                    BError.NOT_EXIST, String.format("Payment %s", pid)));
-
-            userRepository.findById(payment.getUserId())
-                .orElseThrow(() -> new CommonException(BError.NOT_VALID, "userId"));
-
-            // todo: 추론: 낙관 (이유는 중복 결제가 현재 자주 발생하지 않을 것이라고 예상)
-            order = ordersRepository.findByIdWithPessimisticLock(payment.getOrdersId())
-                .orElseThrow(() -> new CommonException(BError.NOT_VALID, "orderId"));
-
-            order.validateNotCompleted();
-
-            List<OrderItem> orderItems = orderItemRepository.findAllByOrdersId(order.getId());
-            if (orderItems.isEmpty()) { // 서비스에 위임
-                throw new CommonException(BError.NOT_VALID, "orderId");
-            }
-
-            // todo: 일단은 기아 현상이 발생하더라도 데드락 발생을 없애고 싶음.
-            // todo: 이 부분은 튜닝이 매우 필요함!
-            List<OrderItem> sortedOrderItems = orderItems.stream()
-                .sorted(Comparator.comparing(OrderItem::getProductId)) // productId 오름차순 정렬
-                .toList();
-
-            List<Inventory> deductedInventories = sortedOrderItems.stream()
-                .map(orderItem -> {
-                    Inventory inventory = inventoryRepository.findWithWriteLockByProductId(
-                            orderItem.getProductId())
-                        .orElseThrow(() -> new CommonException(BError.NOT_VALID, "productId"));
-                    return inventory.deductStock(orderItem.getQuantity());
-                })
-                .toList();
-
-            inventoryRepository.saveAll(deductedInventories);
-            ordersRepository.save(order.completeOrder());
-            payment = paymentRepository.save(payment.approve());
-
-            // 트랜잭션 커밋
-            transactionManager.commit(status);
-        } catch (CommonException e) {
-            // 예외 발생 시 롤백
-            transactionManager.rollback(status);
-            throw e;
-        } catch (Exception e) {
-            transactionManager.rollback(status);
-            throw new CommonException(BError.INTERNAL_SERVER_ERROR, "approvePayment() - 결제 승인 중 오류 발생");
-        }
-
-        // 트랜잭션 커밋 후 이벤트 발행
-        KakaoPayApproveEvent event = KakaoPayApproveEvent.publish(payment, token, pid);
-        eventPublisher.publishEvent(event);
+        approvePaymentStrategy.approvePayment(pid, token);
     }
-
-    // ----------------------[밑에 로직들은 핵심이 아니기에 우선순위에 배제] ---------------------------
 
     /**
      * 주문 페이지 조회용 (결제 전)

--- a/src/main/java/com/sellect/server/order/application/v1/approvepayment/ApprovePaymentConfig.java
+++ b/src/main/java/com/sellect/server/order/application/v1/approvepayment/ApprovePaymentConfig.java
@@ -1,0 +1,14 @@
+package com.sellect.server.order.application.v1.approvepayment;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ApprovePaymentConfig {
+
+    @Bean
+    public ApprovePaymentStrategy approvePaymentStrategy(ApprovePaymentV1 v1) {
+        return v1; // 데드락에 대한 회피 방식 (정렬) -> 기아현상 발생
+
+    }
+}

--- a/src/main/java/com/sellect/server/order/application/v1/approvepayment/ApprovePaymentConfig.java
+++ b/src/main/java/com/sellect/server/order/application/v1/approvepayment/ApprovePaymentConfig.java
@@ -7,8 +7,17 @@ import org.springframework.context.annotation.Configuration;
 public class ApprovePaymentConfig {
 
     @Bean
-    public ApprovePaymentStrategy approvePaymentStrategy(ApprovePaymentV1 v1) {
-        return v1; // 데드락에 대한 회피 방식 (정렬) -> 기아현상 발생
-
+    public ApprovePaymentStrategy approvePaymentStrategy(ApprovePaymentV0 v0) {
+        return v0; // 기존 코드: 데드락에 대한 아무런 조치가 없음
     }
+//
+//    @Bean
+//    public ApprovePaymentStrategy approvePaymentStrategy(ApprovePaymentV1 v1) {
+//        return v1; // 방법 1. 데드락에 대한 회피 방식 (정렬) -> 기아현상 발생
+//    }
+//
+//    @Bean
+//    public ApprovePaymentStrategy approvePaymentStrategy(ApprovePaymentV2 v2) {
+//        return v2; // 방법 2. 격리 수준을 SERIALIZABLE로 변경 (어느 정도 성능상 안 좋은지 직접 확인해보고 싶음)
+//    }
 }

--- a/src/main/java/com/sellect/server/order/application/v1/approvepayment/ApprovePaymentConfig.java
+++ b/src/main/java/com/sellect/server/order/application/v1/approvepayment/ApprovePaymentConfig.java
@@ -20,4 +20,9 @@ public class ApprovePaymentConfig {
 //    public ApprovePaymentStrategy approvePaymentStrategy(ApprovePaymentV2 v2) {
 //        return v2; // 방법 2. 격리 수준을 SERIALIZABLE로 변경 (어느 정도 성능상 안 좋은지 직접 확인해보고 싶음)
 //    }
+//
+//    @Bean
+//    public ApprovePaymentStrategy approvePaymentStrategy(ApprovePaymentV3 v3) {
+//        return v3; // 방법 3. 데드락 발생 시 재시도 로직 추가
+//    }
 }

--- a/src/main/java/com/sellect/server/order/application/v1/approvepayment/ApprovePaymentStrategy.java
+++ b/src/main/java/com/sellect/server/order/application/v1/approvepayment/ApprovePaymentStrategy.java
@@ -1,0 +1,6 @@
+package com.sellect.server.order.application.v1.approvepayment;
+
+public interface ApprovePaymentStrategy {
+
+    void approvePayment(final Long pid, final String token);
+}

--- a/src/main/java/com/sellect/server/order/application/v1/approvepayment/ApprovePaymentV0.java
+++ b/src/main/java/com/sellect/server/order/application/v1/approvepayment/ApprovePaymentV0.java
@@ -1,0 +1,96 @@
+package com.sellect.server.order.application.v1.approvepayment;
+
+import com.sellect.server.auth.repository.user.UserRepository;
+import com.sellect.server.common.exception.CommonException;
+import com.sellect.server.common.exception.enums.BError;
+import com.sellect.server.order.domain.OrderItem;
+import com.sellect.server.order.domain.Orders;
+import com.sellect.server.order.repository.OrderItemRepository;
+import com.sellect.server.order.repository.OrdersRepository;
+import com.sellect.server.payment.domain.Payment;
+import com.sellect.server.payment.event.KakaoPayApproveEvent;
+import com.sellect.server.payment.repository.PaymentRepository;
+import com.sellect.server.product.domain.Inventory;
+import com.sellect.server.product.repository.InventoryRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.TransactionStatus;
+import org.springframework.transaction.support.DefaultTransactionDefinition;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ApprovePaymentV0 implements ApprovePaymentStrategy {
+
+    private final UserRepository userRepository;
+    private final OrdersRepository ordersRepository;
+    private final OrderItemRepository orderItemRepository;
+    private final InventoryRepository inventoryRepository;
+    private final PaymentRepository paymentRepository;
+    private final PlatformTransactionManager transactionManager;
+    private final ApplicationEventPublisher eventPublisher;
+
+    // 기존 코드: 데드락에 대한 아무런 조치가 없음
+    @Override
+    public void approvePayment(final Long pid, final String token) {
+
+        // 트랜잭션 정의 및 시작
+        TransactionDefinition definition = new DefaultTransactionDefinition();
+        TransactionStatus status = transactionManager.getTransaction(definition);
+
+        Payment payment;
+        Orders order;
+
+        try {
+            payment = paymentRepository.findByPid(pid)
+                .orElseThrow(() -> new CommonException(
+                    BError.NOT_EXIST, String.format("Payment %s", pid)));
+
+            userRepository.findById(payment.getUserId())
+                .orElseThrow(() -> new CommonException(BError.NOT_VALID, "userId"));
+
+            // todo: 추론: 낙관 (이유는 중복 결제가 현재 자주 발생하지 않을 것이라고 예상)
+            order = ordersRepository.findByIdWithPessimisticLock(payment.getOrdersId())
+                .orElseThrow(() -> new CommonException(BError.NOT_VALID, "orderId"));
+
+            order.validateNotCompleted();
+
+            List<OrderItem> orderItems = orderItemRepository.findAllByOrdersId(order.getId());
+            if (orderItems.isEmpty()) { // 서비스에 위임
+                throw new CommonException(BError.NOT_VALID, "orderId");
+            }
+
+            List<Inventory> deductedInventories = orderItems.stream()
+                .map(orderItem -> {
+                    Inventory inventory = inventoryRepository.findWithWriteLockByProductId(
+                            orderItem.getProductId())
+                        .orElseThrow(() -> new CommonException(BError.NOT_VALID, "productId"));
+                    return inventory.deductStock(orderItem.getQuantity());
+                })
+                .toList();
+
+            inventoryRepository.saveAll(deductedInventories);
+            ordersRepository.save(order.completeOrder());
+            payment = paymentRepository.save(payment.approve());
+
+            // 트랜잭션 커밋
+            transactionManager.commit(status);
+        } catch (CommonException e) {
+            // 예외 발생 시 롤백
+            transactionManager.rollback(status);
+            throw e;
+        } catch (Exception e) {
+            transactionManager.rollback(status);
+            throw new CommonException(BError.INTERNAL_SERVER_ERROR, "approvePayment() - 결제 승인 중 오류 발생");
+        }
+
+        // 트랜잭션 커밋 후 이벤트 발행
+        KakaoPayApproveEvent event = KakaoPayApproveEvent.publish(payment, token, pid);
+        eventPublisher.publishEvent(event);
+    }
+}

--- a/src/main/java/com/sellect/server/order/application/v1/approvepayment/ApprovePaymentV0.java
+++ b/src/main/java/com/sellect/server/order/application/v1/approvepayment/ApprovePaymentV0.java
@@ -76,7 +76,6 @@ public class ApprovePaymentV0 implements ApprovePaymentStrategy {
 
             inventoryRepository.saveAll(deductedInventories);
             ordersRepository.save(order.completeOrder());
-            payment = paymentRepository.save(payment.approve());
 
             // 트랜잭션 커밋
             transactionManager.commit(status);

--- a/src/main/java/com/sellect/server/order/application/v1/approvepayment/ApprovePaymentV0.java
+++ b/src/main/java/com/sellect/server/order/application/v1/approvepayment/ApprovePaymentV0.java
@@ -47,7 +47,7 @@ public class ApprovePaymentV0 implements ApprovePaymentStrategy {
         Orders order;
 
         try {
-            payment = paymentRepository.findByPid(pid)
+            payment = paymentRepository.findByReadyPid(pid)
                 .orElseThrow(() -> new CommonException(
                     BError.NOT_EXIST, String.format("Payment %s", pid)));
 

--- a/src/main/java/com/sellect/server/order/application/v1/approvepayment/ApprovePaymentV1.java
+++ b/src/main/java/com/sellect/server/order/application/v1/approvepayment/ApprovePaymentV1.java
@@ -82,7 +82,6 @@ public class ApprovePaymentV1 implements ApprovePaymentStrategy {
 
             inventoryRepository.saveAll(deductedInventories);
             ordersRepository.save(order.completeOrder());
-            payment = paymentRepository.save(payment.approve());
 
             // 트랜잭션 커밋
             transactionManager.commit(status);

--- a/src/main/java/com/sellect/server/order/application/v1/approvepayment/ApprovePaymentV1.java
+++ b/src/main/java/com/sellect/server/order/application/v1/approvepayment/ApprovePaymentV1.java
@@ -1,0 +1,102 @@
+package com.sellect.server.order.application.v1.approvepayment;
+
+import com.sellect.server.auth.repository.user.UserRepository;
+import com.sellect.server.common.exception.CommonException;
+import com.sellect.server.common.exception.enums.BError;
+import com.sellect.server.order.domain.OrderItem;
+import com.sellect.server.order.domain.Orders;
+import com.sellect.server.order.repository.OrderItemRepository;
+import com.sellect.server.order.repository.OrdersRepository;
+import com.sellect.server.payment.domain.Payment;
+import com.sellect.server.payment.event.KakaoPayApproveEvent;
+import com.sellect.server.payment.repository.PaymentRepository;
+import com.sellect.server.product.domain.Inventory;
+import com.sellect.server.product.repository.InventoryRepository;
+import java.util.Comparator;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.TransactionStatus;
+import org.springframework.transaction.support.DefaultTransactionDefinition;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ApprovePaymentV1 implements ApprovePaymentStrategy {
+
+    private final UserRepository userRepository;
+    private final OrdersRepository ordersRepository;
+    private final OrderItemRepository orderItemRepository;
+    private final InventoryRepository inventoryRepository;
+    private final PaymentRepository paymentRepository;
+    private final PlatformTransactionManager transactionManager;
+    private final ApplicationEventPublisher eventPublisher;
+
+    // 데드락에 대한 회피 방식 (정렬) -> 기아현상 발생
+    @Override
+    public void approvePayment(final Long pid, final String token) {
+
+        // 트랜잭션 정의 및 시작
+        TransactionDefinition definition = new DefaultTransactionDefinition();
+        TransactionStatus status = transactionManager.getTransaction(definition);
+
+        Payment payment;
+        Orders order;
+
+        try {
+            payment = paymentRepository.findByPid(pid)
+                .orElseThrow(() -> new CommonException(
+                    BError.NOT_EXIST, String.format("Payment %s", pid)));
+
+            userRepository.findById(payment.getUserId())
+                .orElseThrow(() -> new CommonException(BError.NOT_VALID, "userId"));
+
+            // todo: 추론: 낙관 (이유는 중복 결제가 현재 자주 발생하지 않을 것이라고 예상)
+            order = ordersRepository.findByIdWithPessimisticLock(payment.getOrdersId())
+                .orElseThrow(() -> new CommonException(BError.NOT_VALID, "orderId"));
+
+            order.validateNotCompleted();
+
+            List<OrderItem> orderItems = orderItemRepository.findAllByOrdersId(order.getId());
+            if (orderItems.isEmpty()) { // 서비스에 위임
+                throw new CommonException(BError.NOT_VALID, "orderId");
+            }
+
+            // 해결법 (1) - 데드락 회피 -> 예상 : 기아현상 발생
+            List<OrderItem> sortedOrderItems = orderItems.stream()
+                .sorted(Comparator.comparing(OrderItem::getProductId)) // productId 오름차순 정렬
+                .toList();
+
+            List<Inventory> deductedInventories = sortedOrderItems.stream()
+                .map(orderItem -> {
+                    Inventory inventory = inventoryRepository.findWithWriteLockByProductId(
+                            orderItem.getProductId())
+                        .orElseThrow(() -> new CommonException(BError.NOT_VALID, "productId"));
+                    return inventory.deductStock(orderItem.getQuantity());
+                })
+                .toList();
+
+            inventoryRepository.saveAll(deductedInventories);
+            ordersRepository.save(order.completeOrder());
+            payment = paymentRepository.save(payment.approve());
+
+            // 트랜잭션 커밋
+            transactionManager.commit(status);
+        } catch (CommonException e) {
+            // 예외 발생 시 롤백
+            transactionManager.rollback(status);
+            throw e;
+        } catch (Exception e) {
+            transactionManager.rollback(status);
+            throw new CommonException(BError.INTERNAL_SERVER_ERROR, "approvePayment() - 결제 승인 중 오류 발생");
+        }
+
+        // 트랜잭션 커밋 후 이벤트 발행
+        KakaoPayApproveEvent event = KakaoPayApproveEvent.publish(payment, token, pid);
+        eventPublisher.publishEvent(event);
+    }
+}

--- a/src/main/java/com/sellect/server/order/application/v1/approvepayment/ApprovePaymentV1.java
+++ b/src/main/java/com/sellect/server/order/application/v1/approvepayment/ApprovePaymentV1.java
@@ -48,7 +48,7 @@ public class ApprovePaymentV1 implements ApprovePaymentStrategy {
         Orders order;
 
         try {
-            payment = paymentRepository.findByPid(pid)
+            payment = paymentRepository.findByReadyPid(pid)
                 .orElseThrow(() -> new CommonException(
                     BError.NOT_EXIST, String.format("Payment %s", pid)));
 

--- a/src/main/java/com/sellect/server/order/application/v1/approvepayment/ApprovePaymentV1.java
+++ b/src/main/java/com/sellect/server/order/application/v1/approvepayment/ApprovePaymentV1.java
@@ -36,7 +36,7 @@ public class ApprovePaymentV1 implements ApprovePaymentStrategy {
     private final PlatformTransactionManager transactionManager;
     private final ApplicationEventPublisher eventPublisher;
 
-    // 데드락에 대한 회피 방식 (정렬) -> 기아현상 발생
+    // 방법 1. 데드락에 대한 회피 방식 (정렬) -> 기아현상 발생
     @Override
     public void approvePayment(final Long pid, final String token) {
 

--- a/src/main/java/com/sellect/server/order/application/v1/approvepayment/ApprovePaymentV2.java
+++ b/src/main/java/com/sellect/server/order/application/v1/approvepayment/ApprovePaymentV2.java
@@ -76,7 +76,6 @@ public class ApprovePaymentV2 implements ApprovePaymentStrategy {
 
             inventoryRepository.saveAll(deductedInventories);
             ordersRepository.save(order.completeOrder());
-            payment = paymentRepository.save(payment.approve());
 
             // 트랜잭션 커밋
             transactionManager.commit(status);

--- a/src/main/java/com/sellect/server/order/application/v1/approvepayment/ApprovePaymentV2.java
+++ b/src/main/java/com/sellect/server/order/application/v1/approvepayment/ApprovePaymentV2.java
@@ -1,0 +1,96 @@
+package com.sellect.server.order.application.v1.approvepayment;
+
+import com.sellect.server.auth.repository.user.UserRepository;
+import com.sellect.server.common.exception.CommonException;
+import com.sellect.server.common.exception.enums.BError;
+import com.sellect.server.order.domain.OrderItem;
+import com.sellect.server.order.domain.Orders;
+import com.sellect.server.order.repository.OrderItemRepository;
+import com.sellect.server.order.repository.OrdersRepository;
+import com.sellect.server.payment.domain.Payment;
+import com.sellect.server.payment.event.KakaoPayApproveEvent;
+import com.sellect.server.payment.repository.PaymentRepository;
+import com.sellect.server.product.domain.Inventory;
+import com.sellect.server.product.repository.InventoryRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.TransactionStatus;
+import org.springframework.transaction.support.DefaultTransactionDefinition;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ApprovePaymentV2 implements ApprovePaymentStrategy {
+
+    private final UserRepository userRepository;
+    private final OrdersRepository ordersRepository;
+    private final OrderItemRepository orderItemRepository;
+    private final InventoryRepository inventoryRepository;
+    private final PaymentRepository paymentRepository;
+    private final PlatformTransactionManager transactionManager;
+    private final ApplicationEventPublisher eventPublisher;
+
+    // 방법 2. 격리 수준을 SERIALIZABLE로 변경 (어느 정도 성능상 안 좋은지 직접 확인해보고 싶음)
+    @Override
+    public void approvePayment(final Long pid, final String token) {
+
+        DefaultTransactionDefinition definition = new DefaultTransactionDefinition();
+        definition.setIsolationLevel(TransactionDefinition.ISOLATION_SERIALIZABLE);
+        log.info("Isolation Level: {}", definition.getIsolationLevel()); // 확인용 로그 - 8
+        TransactionStatus status = transactionManager.getTransaction(definition);
+
+        Payment payment;
+        Orders order;
+
+        try {
+            payment = paymentRepository.findByPid(pid)
+                .orElseThrow(() -> new CommonException(
+                    BError.NOT_EXIST, String.format("Payment %s", pid)));
+
+            userRepository.findById(payment.getUserId())
+                .orElseThrow(() -> new CommonException(BError.NOT_VALID, "userId"));
+
+            order = ordersRepository.findByIdWithPessimisticLock(payment.getOrdersId())
+                .orElseThrow(() -> new CommonException(BError.NOT_VALID, "orderId"));
+
+            order.validateNotCompleted();
+
+            List<OrderItem> orderItems = orderItemRepository.findAllByOrdersId(order.getId());
+            if (orderItems.isEmpty()) { // 서비스에 위임
+                throw new CommonException(BError.NOT_VALID, "orderId");
+            }
+
+            List<Inventory> deductedInventories = orderItems.stream()
+                .map(orderItem -> {
+                    Inventory inventory = inventoryRepository.findWithWriteLockByProductId(
+                            orderItem.getProductId())
+                        .orElseThrow(() -> new CommonException(BError.NOT_VALID, "productId"));
+                    return inventory.deductStock(orderItem.getQuantity());
+                })
+                .toList();
+
+            inventoryRepository.saveAll(deductedInventories);
+            ordersRepository.save(order.completeOrder());
+            payment = paymentRepository.save(payment.approve());
+
+            // 트랜잭션 커밋
+            transactionManager.commit(status);
+        } catch (CommonException e) {
+            // 예외 발생 시 롤백
+            transactionManager.rollback(status);
+            throw e;
+        } catch (Exception e) {
+            transactionManager.rollback(status);
+            throw new CommonException(BError.INTERNAL_SERVER_ERROR, "approvePayment() - 결제 승인 중 오류 발생");
+        }
+
+        // 트랜잭션 커밋 후 이벤트 발행
+        KakaoPayApproveEvent event = KakaoPayApproveEvent.publish(payment, token, pid);
+        eventPublisher.publishEvent(event);
+    }
+}

--- a/src/main/java/com/sellect/server/order/application/v1/approvepayment/ApprovePaymentV2.java
+++ b/src/main/java/com/sellect/server/order/application/v1/approvepayment/ApprovePaymentV2.java
@@ -41,7 +41,7 @@ public class ApprovePaymentV2 implements ApprovePaymentStrategy {
 
         DefaultTransactionDefinition definition = new DefaultTransactionDefinition();
         definition.setIsolationLevel(TransactionDefinition.ISOLATION_SERIALIZABLE);
-        log.info("Isolation Level: {}", definition.getIsolationLevel()); // 확인용 로그 - 8
+//        log.info("Isolation Level: {}", definition.getIsolationLevel()); // 확인용 로그 - 8
         TransactionStatus status = transactionManager.getTransaction(definition);
 
         Payment payment;

--- a/src/main/java/com/sellect/server/order/application/v1/approvepayment/ApprovePaymentV2.java
+++ b/src/main/java/com/sellect/server/order/application/v1/approvepayment/ApprovePaymentV2.java
@@ -48,7 +48,7 @@ public class ApprovePaymentV2 implements ApprovePaymentStrategy {
         Orders order;
 
         try {
-            payment = paymentRepository.findByPid(pid)
+            payment = paymentRepository.findByReadyPid(pid)
                 .orElseThrow(() -> new CommonException(
                     BError.NOT_EXIST, String.format("Payment %s", pid)));
 

--- a/src/main/java/com/sellect/server/order/application/v1/approvepayment/ApprovePaymentV3.java
+++ b/src/main/java/com/sellect/server/order/application/v1/approvepayment/ApprovePaymentV3.java
@@ -78,7 +78,6 @@ public class ApprovePaymentV3 implements ApprovePaymentStrategy {
 
                 inventoryRepository.saveAll(deductedInventories);
                 ordersRepository.save(order.completeOrder());
-                payment = paymentRepository.save(payment.approve());
 
                 // 트랜잭션 커밋
                 transactionManager.commit(status);

--- a/src/main/java/com/sellect/server/order/application/v1/approvepayment/ApprovePaymentV3.java
+++ b/src/main/java/com/sellect/server/order/application/v1/approvepayment/ApprovePaymentV3.java
@@ -1,0 +1,113 @@
+package com.sellect.server.order.application.v1.approvepayment;
+
+import com.sellect.server.auth.repository.user.UserRepository;
+import com.sellect.server.common.exception.CommonException;
+import com.sellect.server.common.exception.enums.BError;
+import com.sellect.server.order.domain.OrderItem;
+import com.sellect.server.order.domain.Orders;
+import com.sellect.server.order.repository.OrderItemRepository;
+import com.sellect.server.order.repository.OrdersRepository;
+import com.sellect.server.payment.domain.Payment;
+import com.sellect.server.payment.event.KakaoPayApproveEvent;
+import com.sellect.server.payment.repository.PaymentRepository;
+import com.sellect.server.product.domain.Inventory;
+import com.sellect.server.product.repository.InventoryRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.TransactionStatus;
+import org.springframework.transaction.support.DefaultTransactionDefinition;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ApprovePaymentV3 implements ApprovePaymentStrategy {
+
+    public static final int MAX_RETRIES = 3;
+
+    private final UserRepository userRepository;
+    private final OrdersRepository ordersRepository;
+    private final OrderItemRepository orderItemRepository;
+    private final InventoryRepository inventoryRepository;
+    private final PaymentRepository paymentRepository;
+    private final PlatformTransactionManager transactionManager;
+    private final ApplicationEventPublisher eventPublisher;
+
+    // 방법 3. 데드락 발생 시 재시도 로직 추가
+    @Override
+    public void approvePayment(final Long pid, final String token) {
+        int retries = MAX_RETRIES; // 재시도 횟수
+        Payment payment = null;
+
+        while (retries > 0) {
+            // 트랜잭션 정의 및 시작
+            TransactionDefinition definition = new DefaultTransactionDefinition();
+            TransactionStatus status = transactionManager.getTransaction(definition);
+
+            Orders order;
+            try {
+                payment = paymentRepository.findByReadyPid(pid)
+                    .orElseThrow(() -> new CommonException(BError.NOT_EXIST,
+                        String.format("Payment %s", pid)));
+
+                userRepository.findById(payment.getUserId())
+                    .orElseThrow(() -> new CommonException(BError.NOT_VALID, "userId"));
+
+                order = ordersRepository.findByIdWithPessimisticLock(payment.getOrdersId())
+                    .orElseThrow(() -> new CommonException(BError.NOT_VALID, "orderId"));
+
+                order.validateNotCompleted();
+
+                List<OrderItem> orderItems = orderItemRepository.findAllByOrdersId(order.getId());
+                if (orderItems.isEmpty()) {
+                    throw new CommonException(BError.NOT_VALID, "orderId");
+                }
+
+                List<Inventory> deductedInventories = orderItems.stream()
+                    .map(orderItem -> {
+                        Inventory inventory = inventoryRepository.findWithWriteLockByProductId(
+                                orderItem.getProductId())
+                            .orElseThrow(() -> new CommonException(BError.NOT_VALID, "productId"));
+                        return inventory.deductStock(orderItem.getQuantity());
+                    })
+                    .toList();
+
+                inventoryRepository.saveAll(deductedInventories);
+                ordersRepository.save(order.completeOrder());
+                payment = paymentRepository.save(payment.approve());
+
+                // 트랜잭션 커밋
+                transactionManager.commit(status);
+                break;
+            } catch (CommonException e) {
+                transactionManager.rollback(status);
+                throw e; // 비즈니스 예외는 재시도 없이 바로 반환
+            } catch (Exception e) {
+                transactionManager.rollback(status);
+                retries--;
+                if (retries == 0) {
+                    throw new CommonException(BError.INTERNAL_SERVER_ERROR,
+                        "approvePayment() - 결제 승인 실패: 최대 재시도 횟수 초과", e.getMessage());
+                }
+                log.info("결제 승인 재시도 pid: {}, 남은 재시도 횟수: {}", pid, retries);
+                try {
+                    Thread.sleep(100); // 100ms 대기
+                } catch (InterruptedException ie) {
+                    Thread.currentThread().interrupt();
+                    throw new CommonException(BError.INTERNAL_SERVER_ERROR,
+                        "approvePayment() - 재시도 중 인터럽트 발생", ie.getMessage());
+                }
+            }
+        }
+
+        if (payment != null) {
+            // 트랜잭션 커밋 후 이벤트 발행
+            KakaoPayApproveEvent event = KakaoPayApproveEvent.publish(payment, token, pid);
+            eventPublisher.publishEvent(event);
+        }
+    }
+}

--- a/src/main/java/com/sellect/server/payment/application/PaymentServiceV1.java
+++ b/src/main/java/com/sellect/server/payment/application/PaymentServiceV1.java
@@ -70,10 +70,12 @@ public class PaymentServiceV1 {
         boolean success = false;
         String errorMsg = null;
 
+        Payment approvePayment = saveApprovePayment(event);
+
         while (retryCount <= 1 && !success) {
             log.info("카카오페이 승인 요청 시도: retryCount={}, pid={}", retryCount, event.getPid());
             try {
-                requestKakaoPayApporve(event, event.getPayment());
+                requestKakaoPayApporve(event, approvePayment);
                 success = true;
             } catch (ResourceAccessException | HttpServerErrorException e) {
                 retryCount++;
@@ -92,6 +94,16 @@ public class PaymentServiceV1 {
 
         if (!success) {
             throw new CommonException(BError.PAYMENT_FAILED, "카카오페이 결제 승인 실패: " + errorMsg);
+        }
+    }
+
+    private Payment saveApprovePayment(final KakaoPayApproveEvent event) {
+        try {
+            Payment approvePayment = event.getPayment().approve();
+            return paymentRepository.save(approvePayment);
+        } catch (DataAccessException e) {
+            log.error("결제 승인 상태 저장 실패: pid={}", event.getPid(), e);
+            throw new CommonException(BError.DB_ERROR, "결제 승인 상태 저장 실패");
         }
     }
 

--- a/src/main/java/com/sellect/server/payment/application/PaymentServiceV1.java
+++ b/src/main/java/com/sellect/server/payment/application/PaymentServiceV1.java
@@ -70,12 +70,10 @@ public class PaymentServiceV1 {
         boolean success = false;
         String errorMsg = null;
 
-        Payment approvePayment = event.getPayment();
-
         while (retryCount <= 1 && !success) {
             log.info("카카오페이 승인 요청 시도: retryCount={}, pid={}", retryCount, event.getPid());
             try {
-                requestKakaoPayApporve(event, approvePayment);
+                requestKakaoPayApporve(event, event.getPayment());
                 success = true;
             } catch (ResourceAccessException | HttpServerErrorException e) {
                 retryCount++;

--- a/src/main/java/com/sellect/server/payment/application/PaymentServiceV1.java
+++ b/src/main/java/com/sellect/server/payment/application/PaymentServiceV1.java
@@ -70,7 +70,7 @@ public class PaymentServiceV1 {
         boolean success = false;
         String errorMsg = null;
 
-        Payment approvePayment = saveApprovePayment(event);
+        Payment approvePayment = event.getPayment();
 
         while (retryCount <= 1 && !success) {
             log.info("카카오페이 승인 요청 시도: retryCount={}, pid={}", retryCount, event.getPid());
@@ -96,18 +96,6 @@ public class PaymentServiceV1 {
             throw new CommonException(BError.PAYMENT_FAILED, "카카오페이 결제 승인 실패: " + errorMsg);
         }
     }
-
-
-    private Payment saveApprovePayment(final KakaoPayApproveEvent event) {
-        try {
-            Payment approvePayment = event.getPayment().approve();
-            return paymentRepository.save(approvePayment);
-        } catch (DataAccessException e) {
-            log.error("결제 승인 상태 저장 실패: pid={}", event.getPid(), e);
-            throw new CommonException(BError.DB_ERROR, "결제 승인 상태 저장 실패");
-        }
-    }
-
 
     private void createAndSavePreparedPayment(KakaoPayReadyEvent event, Long pid,
         KakaoPayReadyResponse response) {

--- a/src/main/java/com/sellect/server/payment/application/v0/PaymentServiceV0.java
+++ b/src/main/java/com/sellect/server/payment/application/v0/PaymentServiceV0.java
@@ -1,4 +1,4 @@
-package com.sellect.server.payment.application;
+package com.sellect.server.payment.application.v0;
 
 import com.github.f4b6a3.tsid.TsidCreator;
 import com.sellect.server.auth.domain.User;

--- a/src/main/java/com/sellect/server/payment/application/v1/PaymentCompensationServiceV1.java
+++ b/src/main/java/com/sellect/server/payment/application/v1/PaymentCompensationServiceV1.java
@@ -1,4 +1,4 @@
-package com.sellect.server.payment.application;
+package com.sellect.server.payment.application.v1;
 
 import com.sellect.server.common.exception.CommonException;
 import com.sellect.server.common.exception.enums.BError;

--- a/src/main/java/com/sellect/server/payment/application/v1/PaymentServiceV1.java
+++ b/src/main/java/com/sellect/server/payment/application/v1/PaymentServiceV1.java
@@ -1,4 +1,4 @@
-package com.sellect.server.payment.application;
+package com.sellect.server.payment.application.v1;
 
 import com.github.f4b6a3.tsid.TsidCreator;
 import com.sellect.server.common.exception.CommonException;

--- a/src/main/java/com/sellect/server/payment/event/listener/PaymentCompensationTransactionEventListener.java
+++ b/src/main/java/com/sellect/server/payment/event/listener/PaymentCompensationTransactionEventListener.java
@@ -1,6 +1,6 @@
 package com.sellect.server.payment.event.listener;
 
-import com.sellect.server.payment.application.PaymentCompensationServiceV1;
+import com.sellect.server.payment.application.v1.PaymentCompensationServiceV1;
 import com.sellect.server.payment.event.PaymentApproveFailedEvent;
 import com.sellect.server.payment.event.PaymentPrepareFailedEvent;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/sellect/server/payment/event/listener/PaymentEventListener.java
+++ b/src/main/java/com/sellect/server/payment/event/listener/PaymentEventListener.java
@@ -2,7 +2,7 @@ package com.sellect.server.payment.event.listener;
 
 import com.sellect.server.common.exception.CommonException;
 import com.sellect.server.order.Infrastructure.response.KakaoPayReadyResponse;
-import com.sellect.server.payment.application.PaymentServiceV1;
+import com.sellect.server.payment.application.v1.PaymentServiceV1;
 import com.sellect.server.payment.event.KakaoPayApproveEvent;
 import com.sellect.server.payment.event.KakaoPayReadyEvent;
 import com.sellect.server.payment.event.PaymentApproveFailedEvent;

--- a/src/main/java/com/sellect/server/payment/event/listener/PaymentEventListener.java
+++ b/src/main/java/com/sellect/server/payment/event/listener/PaymentEventListener.java
@@ -22,7 +22,6 @@ public class PaymentEventListener {
     private final PaymentServiceV1 paymentService;
     private final ApplicationEventPublisher eventPublisher;
 
-    @Async("preparePaymentExecutor")
     @EventListener
     public void kakaoPayReadyEvent(KakaoPayReadyEvent event) {
         try {

--- a/src/main/java/com/sellect/server/payment/repository/PaymentJpaRepository.java
+++ b/src/main/java/com/sellect/server/payment/repository/PaymentJpaRepository.java
@@ -1,5 +1,6 @@
 package com.sellect.server.payment.repository;
 
+import com.sellect.server.payment.domain.PaymentStatus;
 import com.sellect.server.payment.repository.entity.PaymentEntity;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
@@ -7,9 +8,11 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PaymentJpaRepository extends JpaRepository<PaymentEntity, Long> {
+
     Optional<PaymentEntity> findByPid(Long pid);
 
-//    Page<PaymentEntity> findByUid(String uid, Pageable pageable);
-//    Page<PaymentEntity> findById(Long id, Pageable pageable);
     Page<PaymentEntity> findByUserId(Long userId, Pageable pageable);
+
+    Optional<PaymentEntity> findByPidAndStatus(Long pid, PaymentStatus status);
+
 }

--- a/src/main/java/com/sellect/server/payment/repository/PaymentRepository.java
+++ b/src/main/java/com/sellect/server/payment/repository/PaymentRepository.java
@@ -11,6 +11,8 @@ public interface PaymentRepository {
 
     Optional<Payment> findByPid(Long pid);
 
-//    Page<Payment> findPaymentHistoryByUser(String uuid, Pageable pageable);
     Page<Payment> findPaymentHistoryByUser(Long userId, Pageable pageable);
+
+    Optional<Payment> findByReadyPid(Long pid);
+
 }

--- a/src/main/java/com/sellect/server/payment/repository/PaymentRepositoryImpl.java
+++ b/src/main/java/com/sellect/server/payment/repository/PaymentRepositoryImpl.java
@@ -1,6 +1,7 @@
 package com.sellect.server.payment.repository;
 
 import com.sellect.server.payment.domain.Payment;
+import com.sellect.server.payment.domain.PaymentStatus;
 import com.sellect.server.payment.repository.entity.PaymentEntity;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -26,16 +27,18 @@ public class PaymentRepositoryImpl implements PaymentRepository {
         return paymentEntity.map(PaymentEntity::toModel);
     }
 
-//    @Override
-//    public Page<Payment> findPaymentHistoryByUser(String uuid, Pageable pageable) {
-//        Page<PaymentEntity> paymentEntityPage = paymentJpaRepository.findByUid(uuid, pageable);
-//        return paymentEntityPage.map(PaymentEntity::toModel);
-//    }
 
     @Override
     public Page<Payment> findPaymentHistoryByUser(Long userId, Pageable pageable) {
         Page<PaymentEntity> paymentEntityPage = paymentJpaRepository.findByUserId(userId, pageable);
         return paymentEntityPage.map(PaymentEntity::toModel);
+    }
+
+    @Override
+    public Optional<Payment> findByReadyPid(Long pid) {
+        Optional<PaymentEntity> paymentEntity = paymentJpaRepository.findByPidAndStatus(pid,
+            PaymentStatus.READY);
+        return paymentEntity.map(PaymentEntity::toModel);
     }
 
 }

--- a/src/test/java/com/sellect/server/payment/repository/FakePaymentRepository.java
+++ b/src/test/java/com/sellect/server/payment/repository/FakePaymentRepository.java
@@ -58,4 +58,10 @@ public class FakePaymentRepository implements PaymentRepository {
         return new PageImpl<>(subList, pageable, filteredPayments.size());
     }
 
+    // todo: 테스트 코드 작성 시 구현
+    @Override
+    public Optional<Payment> findByReadyPid(Long pid) {
+        return Optional.empty();
+    }
+
 }


### PR DESCRIPTION
## 📣 PaymentService에 대한 로직 변경 및 이벤트리스너에서 preparePayment의 경우에는 동기로 (톰캣 스레드가 처리하도록 변경) - 불필요한 스레드 2개를 사용하는 걸 방지(톰캣, 스프링 스레드)
### 📅(날짜 -  2025.03.29)

### 💬Issue Number
[#(number)] - (keyword)

### 🛠️Type
- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정 -
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

### ✔️PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고 (Ctrl + 클릭하세요.)
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

### 🔖Note
(참고사항을 적어주세요)